### PR TITLE
Support for enum, simple and tuple type type constructors and some structural changes

### DIFF
--- a/ParserCombinator.sig
+++ b/ParserCombinator.sig
@@ -9,7 +9,8 @@ sig
                  | LPAREN        | RPAREN      | DATATYPE
                  | TYPE          | COMMA       | PIPE
                  | LBRACKET      | RBRACKET    | LBRACE
-                 | RBRACE
+                 | RBRACE        | OF          | ASTERISK
+                 | INT
 
   datatype partree = Decl of decl | NA
 

--- a/ParserCombinator.sig
+++ b/ParserCombinator.sig
@@ -18,6 +18,11 @@ sig
            | Value of id * expr
 
   and typeDef = Enum of string
+              | Simple of string * typ
+              | TupleTyp of string * typ list
+
+  and typ = Int
+          | TyVar of string
 
   and id = Id of string 
 

--- a/ParserCombinator.sml
+++ b/ParserCombinator.sml
@@ -9,7 +9,8 @@ struct
                  | LPAREN        | RPAREN      | DATATYPE
                  | TYPE          | COMMA       | PIPE
                  | LBRACKET      | RBRACKET    | LBRACE
-                 | RBRACE
+                 | RBRACE        | OF          | ASTERISK
+                 | INT
 
   datatype partree = Decl of decl | NA
 
@@ -31,6 +32,8 @@ struct
          "val"      => VAL
        | "datatype" => DATATYPE
        | "type"     => TYPE
+       | "of"       => OF
+       | "int"      => INT
        | id         => ID id
 
   fun symbolic str =
@@ -45,6 +48,7 @@ struct
        | "]"  => SOME RBRACKET
        | "{"  => SOME LBRACE
        | "}"  => SOME RBRACE
+       | "*"  => SOME ASTERISK
        | _    => NONE
 
   fun symbTok (str, ss) =


### PR DESCRIPTION
I've added support for simple type constructors, like 'A of int', and tuple type constructors, like 'B of trae \* int \* trae'. I've made a few changes to the structure of the grammar rule functions as well; these might need some (major) restructuring, e.g. based on ML grammar rules.
