### PR TITLE
Addition of a PrettyPrinter, Main file and mldv.mlb basis file

### DIFF
--- a/Main.sml
+++ b/Main.sml
@@ -1,0 +1,24 @@
+(*
+ * MLDataVisualizer main file containing the main function that is 
+ * called automatically on program execution.
+ *)
+
+exception InvalidArguments
+
+fun parseArguments args =
+  case args of
+       [arg] =>
+         let
+           val ptrees = ParserCombinator.parse (ParserCombinator.scan arg)
+         in
+           PrettyPrinter.show ptrees
+         end
+     | _                     => raise InvalidArguments
+
+fun main () = parseArguments (CommandLine.arguments())
+  handle InvalidArguments =>
+           print "InvalidArguments: Do somthing smart here!\n"
+       | ParserCombinator.SyntaxError str =>
+           print ("Syntax error: " ^ str ^ "\n")
+
+val _ = main ()

--- a/ParserCombinator.sml
+++ b/ParserCombinator.sml
@@ -86,7 +86,7 @@ struct
            else (* ignore spaces, line breaks, control characters *)
                 scanning (toks, Substring.dropl (not o Char.isGraph) ss)
 
-  fun scan str = scanning ([], Substring.all str)
+  fun scan str = scanning ([], Substring.full str)
 
   (** The parser combinators *)
   infix 6 $- -$

--- a/PrettyPrinter.sml
+++ b/PrettyPrinter.sml
@@ -22,12 +22,12 @@ struct
          Int n     => Int.toString n
        | Real n    => Real.toString n
        | String s  => s
-       | Tuple es  => "(" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es)
-                      ^ ")"
-       | List es   => "[" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es)
-                      ^ "]"
-       | Record es => "{" ^ foldl op^ "" (map (fn (n,e) => n ^ " = "
-                      ^ showExpr e) es) ^ "}"
+       | Tuple es  =>
+           "(" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es) ^ ")"
+       | List es   =>
+           "[" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es) ^ "]"
+       | Record es =>
+           "{" ^ foldl op^ "" (map (fn (n,e) => n ^ " = " ^ showExpr e) es) ^ "}"
 
   and showTydef tree =
     case tree of

--- a/PrettyPrinter.sml
+++ b/PrettyPrinter.sml
@@ -1,0 +1,47 @@
+signature PRETTY_PRINTER =
+sig
+
+  val show: ParserCombinator.partree list -> unit
+
+end
+
+structure PrettyPrinter :> PRETTY_PRINTER =
+struct
+
+  open ParserCombinator
+
+  fun showPartree tree =
+    case tree of
+         Value (str, exp)       => "val " ^ str ^ " = " ^ showExpr exp ^ "\n"
+       | Datatype (str, tydefs) => "datatype " ^ str ^ " = " ^ 
+           foldl op^ "" (map (fn tydef => showTydef tydef ^ " | ") tydefs)
+           ^ "\n"
+
+  and showExpr tree =
+    case tree of
+         Int n     => Int.toString n
+       | Real n    => Real.toString n
+       | String s  => s
+       | Tuple es  => "(" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es)
+                      ^ ")"
+       | List es   => "[" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es)
+                      ^ "]"
+       | Record es => "{" ^ foldl op^ "" (map (fn (n,e) => n ^ " = "
+                      ^ showExpr e) es) ^ "}"
+
+  and showTydef tree =
+    case tree of
+         NullaryCon s       => s
+       | UnaryCon (s, t)    => s ^ " of " ^ showTyp t
+       | MultaryCon (s, ts) =>
+           s ^ " of " ^ foldl op^ ""(map (fn t => showTyp t ^ " * ") ts)
+
+  and showTyp tree =
+    case tree of
+         IntTyp  => "int"
+       | RealTyp => "real"
+       | Tyvar s => s
+
+  fun show ptree = app print (map showPartree ptree)
+
+end

--- a/PrettyPrinter.sml
+++ b/PrettyPrinter.sml
@@ -23,18 +23,18 @@ struct
        | Real n    => Real.toString n
        | String s  => s
        | Tuple es  =>
-           "(" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es) ^ ")"
+           "(" ^ foldr op^ "" (map (fn x => showExpr x ^ ", ") es) ^ ")"
        | List es   =>
-           "[" ^ foldl op^ "" (map (fn x => showExpr x ^ ", ") es) ^ "]"
+           "[" ^ foldr op^ "" (map (fn x => showExpr x ^ ", ") es) ^ "]"
        | Record es =>
-           "{" ^ foldl op^ "" (map (fn (n,e) => n ^ " = " ^ showExpr e) es) ^ "}"
+           "{" ^ foldr op^ "" (map (fn (n,e) => n ^ " = " ^ showExpr e) es) ^ "}"
 
   and showTydef tree =
     case tree of
          NullaryCon s       => s
        | UnaryCon (s, t)    => s ^ " of " ^ showTyp t
        | MultaryCon (s, ts) =>
-           s ^ " of " ^ foldl op^ ""(map (fn t => showTyp t ^ " * ") ts)
+           s ^ " of " ^ foldr op^ ""(map (fn t => showTyp t ^ " * ") ts)
 
   and showTyp tree =
     case tree of

--- a/README.md
+++ b/README.md
@@ -6,4 +6,13 @@ A SML program for visualizing data structures in SML.
 
 See http://www.mlton.org/ManualPage and http://www.mlton.org/MLBasis for additional information.
 
-    $ mlton project.mlb
+    $ mlton mldv.mlb
+
+
+**Example usage (while in this phase of the project):**
+
+    $ ./mldv "val a = (1234, 3.14) datatype tree = Node of tree * int * tree | Null"
+
+Make sure that the compiled program is executable (it probably already is if you compiled it):
+
+    $ chmod +x ./mldv

--- a/mldv.mlb
+++ b/mldv.mlb
@@ -1,0 +1,8 @@
+(* import libraries *)
+$(SML_LIB)/basis/basis.mlb
+
+(* program files *)
+ParserCombinator.sig
+ParserCombinator.sml
+PrettyPrinter.sml
+Main.sml


### PR DESCRIPTION
I've written a quick and somewhat buggy pretty printer for our partree type. Have a look at PrettyPrinter.sml (quite simple) and Main.sml (simple as well). This way we can test our program by compiling with mlton and running in the terminal (or whatever). Have a look at the new README.md to see how.
I've also changed the 'Substring.all' in ParserCombinator.sml to 'Substring.full' (they seem to be identical), which is available in mlton.
